### PR TITLE
feat(usage): reset usage_last_synced_at on manual usage log

### DIFF
--- a/src/routes/usage.ts
+++ b/src/routes/usage.ts
@@ -64,9 +64,11 @@ router.post('/equipment/:id/usage-logs', upload.single('image'), async (req: Req
       [id, usage_value, notes || null, condition || 'normal', imageUrl, recorded_by || null]
     );
 
-    // 2. Update current_usage in equipment table
+    // 2. Update current_usage in equipment table.
+    // Also reset usage_last_synced_at = NOW() so the auto-sync cron continues
+    // accumulating from this new manual baseline instead of double-counting.
     await client.query(
-      'UPDATE equipment SET current_usage = $1, updated_at = NOW() WHERE equipment_id = $2',
+      'UPDATE equipment SET current_usage = $1, usage_last_synced_at = NOW(), updated_at = NOW() WHERE equipment_id = $2',
       [usage_value, id]
     );
 


### PR DESCRIPTION
## Summary

- เมื่อช่างกรอก usage manual → เพิ่ม `usage_last_synced_at = NOW()` ใน UPDATE query
- ทำให้ auto-sync cron (main_app) ต่อนับจาก baseline ใหม่ที่คนกรอก แทนที่จะ double-count sensor data ก่อนหน้า

## Related
ใช้งานร่วมกับ feat(tasks) ใน backend-qsmart PR #46

## Test plan

- [ ] กรอก usage manual → ตรวจสอบว่า `current_usage` และ `usage_last_synced_at` อัปเดตพร้อมกัน
- [ ] รอ cron รอบถัดไป → ตรวจสอบว่า `current_usage` บวกต่อจากค่าที่กรอก

🤖 Generated with [Claude Code](https://claude.com/claude-code)