### PR TITLE
fix(ci): use sudo for deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Deploy to Production
         run: |
           flock -x /tmp/qsmart-deploy.lock \
-            bash /root/servers/QSMART-SERVER/scripts/deploy.sh
+            sudo bash /root/servers/QSMART-SERVER/scripts/deploy.sh


### PR DESCRIPTION
Runner runs as github-runner user — needs sudo to execute deploy.sh owned by root.