### PR TITLE
fix(ci): use full bash path in sudo deploy command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Deploy to Production
         run: |
           flock -x /tmp/qsmart-deploy.lock \
-            sudo bash /root/servers/QSMART-SERVER/scripts/deploy.sh
+            sudo /usr/bin/bash /root/servers/QSMART-SERVER/scripts/deploy.sh


### PR DESCRIPTION
Use `sudo /usr/bin/bash` to match sudoers NOPASSWD rule exactly.