### PR TITLE
fix(notifications): remove outdated LINE Notify integration

### DIFF
--- a/src/routes/notifications.ts
+++ b/src/routes/notifications.ts
@@ -534,43 +534,6 @@ export async function createNotification(data: {
       data.user_id
     ]);
 
-    // ==== LINE NOTIFY INTEGRATION ====
-    try {
-      // 1. Get user's LINE Notify token
-      const userRes = await pool.query(
-        'SELECT line_notify_token FROM maintenance_users WHERE id = $1',
-        [data.user_id]
-      );
-
-      const lineToken = userRes.rows[0]?.line_notify_token;
-
-      // 2. If token exists, send via LINE Notify API
-      if (lineToken) {
-        // Required module import at the top of file or use dynamic import
-        const axios = require('axios');
-        const qs = require('querystring');
-
-        let notifyMessage = `\n🔔 ${data.title}`;
-        if (data.message) {
-          notifyMessage += `\n📝 ${data.message}`;
-        }
-
-        await axios.post(
-          'https://notify-api.line.me/api/notify',
-          qs.stringify({ message: notifyMessage }),
-          {
-            headers: {
-              'Content-Type': 'application/x-www-form-urlencoded',
-              'Authorization': `Bearer ${lineToken}`
-            }
-          }
-        );
-      }
-    } catch (lineError: any) {
-      console.error('Error sending LINE Notify:', lineError?.response?.data || lineError.message);
-    }
-    // =================================
-
     return msgId;
   } catch (error) {
     console.error('Error creating notification:', error);

--- a/src/server.ts
+++ b/src/server.ts
@@ -149,7 +149,7 @@ async function checkPMSchedules() {
 
     // Get all technicians/admins to notify
     const users = await pool.query(
-      "SELECT id, display_name, line_notify_token FROM maintenance_users WHERE role IN ('admin', 'supervisor', 'technician')"
+      "SELECT id, display_name FROM maintenance_users WHERE role IN ('admin', 'supervisor', 'technician')"
     );
 
     // Get first admin/supervisor for auto-assignment


### PR DESCRIPTION
## Summary
- ลบ LINE Notify API integration ที่ outdated ออก เนื่องจาก `line_notify_token` column ไม่มีใน DB แล้ว
- แก้ `checkPMSchedules()` ที่ crash ทุกชั่วโมง ทำให้ PM auto-ticket และ in-app notification ไม่ทำงาน
- Notification ยังทำงานผ่าน `maintenance_notifications` table และ `noti_list` ใน-app ปกติ

## Test plan
- [ ] PM Schedule checker รันได้โดยไม่มี `❌ Error checking PM schedules`
- [ ] In-app notifications ยังแสดงผลปกติใน LINE LIFF

🤖 Generated with [Claude Code](https://claude.com/claude-code)