### PR TITLE
feat(push): Web Push (VAPID) notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,8 @@ PORT=3002
 DATABASE_URL=postgresql://smartquary_user:CHANGE_ME_Strong_Password_123%21@localhost:5432/smartquary_db
 
 
+
+# Web Push VAPID (generate with: npx web-push generate-vapid-keys)
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+VAPID_EMAIL=mailto:admin@silasrirung.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "helmet": "^8.1.0",
         "multer": "^2.0.2",
         "pg": "^8.18.0",
+        "web-push": "^3.6.7",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -27,6 +28,7 @@
         "@types/multer": "^2.0.0",
         "@types/node": "^20.10.0",
         "@types/pg": "^8.10.9",
+        "@types/web-push": "^3.6.4",
         "prisma": "^5.0.0",
         "tsx": "^4.0.0",
         "typescript": "^5.3.0"
@@ -702,6 +704,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -715,6 +727,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/append-field": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
@@ -726,6 +747,18 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -743,6 +776,12 @@
         "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
@@ -767,6 +806,12 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -966,6 +1011,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1088,7 +1142,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -1224,7 +1277,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1354,6 +1406,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -1373,6 +1434,42 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -1408,6 +1505,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/math-intrinsics": {
@@ -1478,6 +1596,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimist": {
       "version": "1.2.8",
@@ -1586,7 +1710,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -1717,7 +1840,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
       },
@@ -2097,6 +2219,25 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "helmet": "^8.1.0",
     "multer": "^2.0.2",
     "pg": "^8.18.0",
+    "web-push": "^3.6.7",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -36,6 +37,7 @@
     "@types/multer": "^2.0.0",
     "@types/node": "^20.10.0",
     "@types/pg": "^8.10.9",
+    "@types/web-push": "^3.6.4",
     "prisma": "^5.0.0",
     "tsx": "^4.0.0",
     "typescript": "^5.3.0"

--- a/src/routes/maintenance.ts
+++ b/src/routes/maintenance.ts
@@ -2,6 +2,7 @@ import express, { Request, Response, Router } from 'express';
 // mapStatus helper removed as we pass raw status
 import pool from '../config/database.js';
 import { createNotification } from './notifications.js';
+import { sendPushToRoles, sendPushToUser } from '../services/push.service.js';
 
 const router: Router = express.Router();
 
@@ -663,6 +664,31 @@ router.post('/records', upload.array('images', 5), async (req: Request, res: Res
 
     await client.query('COMMIT');
 
+    // In-app + Push: แจ้ง admin/supervisor ว่ามี work order ใหม่ (non-blocking)
+    const notifyAdmins = async () => {
+      const admins = await pool.query(
+        `SELECT id FROM maintenance_users WHERE role IN ('admin','supervisor')`
+      );
+      for (const u of admins.rows) {
+        createNotification({
+          user_id: u.id,
+          title: 'Work Order ใหม่',
+          message: `${workOrder} — ${title || 'ไม่มีหัวข้อ'}`,
+          type: 'info',
+          category: 'maintenance',
+          reference_type: 'maintenance_record',
+          reference_id: record.id,
+        }).catch(() => {});
+      }
+      sendPushToRoles(['admin', 'supervisor'], {
+        title: 'Work Order ใหม่',
+        body: `${workOrder} — ${title || 'ไม่มีหัวข้อ'}`,
+        url: `/maintenance/?record=${record.id}`,
+        tag: `wo-new-${record.id}`,
+      }).catch(() => {});
+    };
+    notifyAdmins().catch(() => {});
+
     res.status(201).json({
       id: String(record.id),
       workOrder: record.work_order,
@@ -834,16 +860,20 @@ router.patch('/records/:id', upload.array('images', 5), async (req: Request, res
 
     await client.query('COMMIT');
 
-    // Send notification to newly assigned user (after commit, non-blocking)
+    // Notifications after commit (non-blocking)
+    const workOrder = result.rows[0]?.work_order;
+    const createdBy: number | null = result.rows[0]?.created_by ?? null;
+
+    const equipmentRes = await pool.query(
+      `SELECT e.equipment_name FROM maintenance_records mr
+       LEFT JOIN equipment e ON e.equipment_id = mr.equipment_id
+       WHERE mr.id = $1`, [id]
+    );
+    const equipmentName = equipmentRes.rows[0]?.equipment_name || workOrder;
+
+    // Assign notification
     const newAssignedTo = assignedTo ?? result.rows[0]?.assigned_to;
     if (assignedTo !== undefined && newAssignedTo && newAssignedTo !== prevAssignedTo) {
-      const workOrder = result.rows[0]?.work_order;
-      const equipmentRes = await pool.query(
-        `SELECT e.equipment_name FROM maintenance_records mr
-         LEFT JOIN equipment e ON e.equipment_id = mr.equipment_id
-         WHERE mr.id = $1`, [id]
-      );
-      const equipmentName = equipmentRes.rows[0]?.equipment_name || workOrder;
       createNotification({
         user_id: newAssignedTo,
         title: 'ได้รับมอบหมายงานซ่อม',
@@ -853,6 +883,41 @@ router.patch('/records/:id', upload.array('images', 5), async (req: Request, res
         reference_type: 'maintenance_record',
         reference_id: parseInt(id),
       }).catch((err: Error) => console.error('Notification error:', err));
+
+      sendPushToUser(newAssignedTo, {
+        title: 'มอบหมายงานใหม่',
+        body: `${workOrder} — ${equipmentName}`,
+        url: `/maintenance/?record=${id}`,
+        tag: `assign-${id}`,
+      }).catch(() => {});
+    }
+
+    // In-app + Push: status change → notify ผู้สร้าง record
+    if (status && createdBy) {
+      const statusLabels: Record<string, string> = {
+        in_progress: 'กำลังดำเนินการ',
+        completed: 'เสร็จสิ้น',
+        cancelled: 'ยกเลิก',
+      };
+      const label = statusLabels[reverseMapStatus(status)];
+      if (label) {
+        createNotification({
+          user_id: createdBy,
+          title: `${workOrder} — ${label}`,
+          message: equipmentName,
+          type: reverseMapStatus(status) === 'completed' ? 'success' : 'info',
+          category: 'maintenance',
+          reference_type: 'maintenance_record',
+          reference_id: parseInt(id),
+        }).catch(() => {});
+
+        sendPushToUser(createdBy, {
+          title: `${workOrder} — ${label}`,
+          body: equipmentName,
+          url: `/maintenance/?record=${id}`,
+          tag: `status-${id}`,
+        }).catch(() => {});
+      }
     }
 
     res.json({

--- a/src/routes/notifications.ts
+++ b/src/routes/notifications.ts
@@ -1,7 +1,58 @@
 import express, { Request, Response, Router } from 'express';
+import webpush from 'web-push';
 import pool from '../config/database.js';
 
 const router: Router = express.Router();
+
+// ===========================================
+// WEB PUSH (VAPID)
+// ===========================================
+
+router.get('/push/vapid-public-key', (_req: Request, res: Response) => {
+  res.json({ publicKey: process.env.VAPID_PUBLIC_KEY ?? null });
+});
+
+router.post('/push/subscribe', async (req: Request, res: Response) => {
+  try {
+    const { userId, subscription } = req.body as {
+      userId: number;
+      subscription: { endpoint: string; keys: { p256dh: string; auth: string } };
+    };
+
+    if (!userId || !subscription?.endpoint) {
+      return res.status(400).json({ error: 'userId and subscription are required' });
+    }
+
+    // sanitizeInputs middleware HTML-encodes slashes — decode back for URL fields
+    const decodeHtml = (s: string) => s.replace(/&#x2F;/g, '/').replace(/&amp;/g, '&');
+    const endpoint = decodeHtml(subscription.endpoint);
+    const p256dh = subscription.keys.p256dh;
+    const auth = subscription.keys.auth;
+
+    await pool.query(
+      `INSERT INTO push_subscriptions (user_id, endpoint, p256dh, auth, user_agent)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (endpoint) DO UPDATE SET user_id = $1, p256dh = $3, auth = $4, user_agent = $5`,
+      [userId, endpoint, p256dh, auth, req.headers['user-agent'] ?? null]
+    );
+
+    res.status(201).json({ ok: true });
+  } catch (error: any) {
+    console.error('Error saving push subscription:', error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.delete('/push/subscribe', async (req: Request, res: Response) => {
+  try {
+    const { endpoint } = req.body as { endpoint: string };
+    if (!endpoint) return res.status(400).json({ error: 'endpoint is required' });
+    await pool.query('DELETE FROM push_subscriptions WHERE endpoint = $1', [endpoint]);
+    res.json({ ok: true });
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
+});
 
 // ===========================================
 // NOTIFICATIONS

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import usageRoutes from './routes/usage.js';
 import setupRoutes from './routes/setup.js';
 import reportsRoutes from './routes/reports.js';
 import notificationsRoutes, { checkAndNotifyOverdue, createNotification } from './routes/notifications.js';
+import { sendPushToRoles } from './services/push.service.js';
 
 import pool from './config/database.js';
 
@@ -307,6 +308,16 @@ async function checkPMSchedules() {
           reference_id: ticketId || schedule.id,
         });
       }
+
+      // Push notification ไปทุก role (ทำหลัง in-app, non-blocking)
+      sendPushToRoles(['admin', 'supervisor', 'technician'], {
+        title: isOverdue
+          ? `PM ถึงกำหนด: ${schedule.equipment_name}`
+          : `PM ใกล้ถึง: ${schedule.equipment_name}`,
+        body: schedule.description || `ทุก ${schedule.interval_value} ชม.${statusText ? ` — ${statusText}` : ''}`,
+        url: '/maintenance',
+        tag: `pm-${schedule.id}`,
+      }).catch(() => {});
 
       notifiedSchedules.push({
         id: schedule.id,

--- a/src/services/push.service.ts
+++ b/src/services/push.service.ts
@@ -1,0 +1,74 @@
+import webpush from 'web-push';
+import pool from '../config/database.js';
+
+if (process.env.VAPID_PUBLIC_KEY && process.env.VAPID_PRIVATE_KEY && process.env.VAPID_EMAIL) {
+  webpush.setVapidDetails(
+    process.env.VAPID_EMAIL,
+    process.env.VAPID_PUBLIC_KEY,
+    process.env.VAPID_PRIVATE_KEY
+  );
+}
+
+export interface PushPayload {
+  title: string;
+  body: string;
+  icon?: string;
+  badge?: string;
+  url?: string;
+  tag?: string;
+}
+
+export async function sendPushToUser(userId: number, payload: PushPayload): Promise<void> {
+  if (!process.env.VAPID_PUBLIC_KEY) return;
+
+  let subs;
+  try {
+    subs = await pool.query(
+      'SELECT id, endpoint, p256dh, auth FROM push_subscriptions WHERE user_id = $1',
+      [userId]
+    );
+  } catch {
+    return;
+  }
+
+  const data = JSON.stringify({
+    title: payload.title,
+    body: payload.body,
+    icon: payload.icon ?? '/android-chrome-192x192.png',
+    badge: payload.badge ?? '/favicon-32x32.png',
+    url: payload.url ?? '/',
+    tag: payload.tag,
+  });
+
+  await Promise.allSettled(
+    subs.rows.map(async (sub) => {
+      try {
+        await webpush.sendNotification(
+          { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+          data
+        );
+      } catch (err: any) {
+        console.error(`[push] send failed endpoint=${sub.endpoint.slice(0, 60)} status=${err.statusCode} body=${err.body} msg=${err.message}`);
+        if (err.statusCode === 410 || err.statusCode === 404) {
+          await pool.query('DELETE FROM push_subscriptions WHERE id = $1', [sub.id]).catch(() => {});
+        }
+      }
+    })
+  );
+}
+
+export async function sendPushToRoles(roles: string[], payload: PushPayload): Promise<void> {
+  if (!process.env.VAPID_PUBLIC_KEY) return;
+
+  let users;
+  try {
+    users = await pool.query(
+      `SELECT id FROM maintenance_users WHERE role = ANY($1::text[])`,
+      [roles]
+    );
+  } catch {
+    return;
+  }
+
+  await Promise.allSettled(users.rows.map((u) => sendPushToUser(u.id, payload)));
+}


### PR DESCRIPTION
## Summary

- Add `push.service.ts` — `sendPushToUser` / `sendPushToRoles` via web-push (VAPID)
- Add VAPID routes: `GET /push/vapid-public-key`, `POST /push/subscribe`, `DELETE /push/subscribe`
- Fix `sanitizeInputs` middleware HTML-encoding push endpoint URLs (decode `&#x2F;` → `/` on save)
- Sync in-app + push on every trigger: new WO, assign, status change (in_progress/completed/cancelled)
- PM cron pushes to all roles
- Deep link URLs `?record=ID` in push payloads for direct navigation
- Graceful: VAPID not configured = no-op; push errors never crash main request

## Test plan

- [ ] `GET /api/notifications/push/vapid-public-key` returns public key
- [ ] `POST /api/notifications/push/subscribe` saves clean endpoint (no HTML entities) to DB
- [ ] `DELETE /api/notifications/push/subscribe` removes from DB
- [ ] Creating work order → push + in-app received by admin/supervisor
- [ ] Status change → push + in-app received by creator
- [ ] Missing VAPID env → server starts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)